### PR TITLE
fix compact mode toolbar background

### DIFF
--- a/dist/userChrome.css
+++ b/dist/userChrome.css
@@ -22,6 +22,7 @@
   --newtab-background-color: var(--overlay) !important;
   --zen-themed-toolbar-bg: var(--base) !important;
   --zen-main-browser-background: var(--base) !important;
+  --zen-main-browser-background-toolbar: var(--base) !important;
 }
 
 #permissions-granted-icon {


### PR DESCRIPTION
when you go compact mode with alt+ctrl+c the toolbar's background wasn't stylized by the theme. this fixes it.