### PR TITLE
chore: updates installation instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,9 +13,10 @@
 
 ## Usage
 
-- Copy `dist/` content to your Zen Browser's profile directory.
-- Edit first line of `userChrome.css` if you want to change default variant to another.
-- Restart your browser.
+1. [Create a `chrome` folder](https://www.userchrome.org/how-create-userchrome-css.html) in your Zen Browser's profile directory.
+2. Copy the contents of the [`dist/` folder](/dist) into your `chrome/` folder.
+3. Edit first line of `userChrome.css` if you want to change default variant to another.
+4. Restart your browser.
 
 ## Gallery
 


### PR DESCRIPTION
Adds a new step to the installation instructions to first create a `chrome` folder and then move the contents of the `dist` directory into this new folder. Also converts the list format from unordered to ordered for more clarity.